### PR TITLE
Convert all documentation and scripts to Traditional Chinese 

### DIFF
--- a/CONNECTION_FIXED.md
+++ b/CONNECTION_FIXED.md
@@ -1,249 +1,200 @@
-# ✅ 前后端连接问题已解决
+# 前後端連接問題診斷與解決方案
 
-## 问题总结
+## 問題診斷結果
 
-### 原始问题
-- ❌ 前后端服务都未运行
-- ❌ 后端无法编译（Maven DNS解析失败）
-- ❌ 前端node_modules依赖不完整
+### 當前狀態
+- ❌ **後端服務未運行** (8080連接埠未被佔用)
+- ❌ **前端開發服務器未運行**
+- ❌ **網路DNS解析失敗** (無法下載Maven依賴)
+- ✅ 前端依賴已安裝 (node_modules存在)
+- ✅ 專案配置正確
 
-### 解决过程
+### 根本原因
+1. 前後端服務都沒有啟動
+2. 後端無法編譯 - Maven無法解析域名下載依賴 (DNS configuration issue)
 
-#### 1. 诊断阶段
-- 发现8080端口未被占用（后端未启动）
-- 发现前端开发服务器未运行
-- 识别出DNS配置问题导致Maven无法下载依赖
+## 架構說明
 
-#### 2. 修复阶段
+### 後端 (Java)
+- **連接埠**: 8080
+- **API路徑**: `/api/v1/*` 和 `/api/*` (向後兼容)
+- **主類**: `app.web.SimpleServer`
+- **依賴**: Gson (2.10.1), Jsoup (1.17.2)
 
-**后端修复：**
-- ✅ 配置DNS (8.8.8.8)
-- ✅ 手动下载依赖JAR:
-  - gson-2.10.1.jar (277KB)
-  - jsoup-1.17.2.jar (436KB)
-- ✅ 修复文件名大小写问题 (Keywordsuggester.java → KeywordSuggester.java)
-- ✅ 使用javac手动编译41个Java源文件
-- ✅ 成功启动后端服务在8080端口
+### 前端 (React + Vite)
+- **開發連接埠**: 默認 5173
+- **代理配置**: `/api` -> `http://localhost:8080`
+- **API調用**: `fetch('/api/search?...')` 會被代理到後端
 
-**前端修复：**
-- ✅ 清理并重新安装node_modules
-- ✅ 修复@rollup/rollup-linux-x64-gnu依赖问题
-- ✅ 成功启动Vite开发服务器在5173端口
+## 解決方案
 
-## 当前状态
+### 方案 A：修復網路並正常啟動 (推薦)
 
-### ✅ 服务运行状态
+#### 1. 修復DNS配置
+\`\`\`bash
+# 創建或更新 /etc/resolv.conf
+sudo bash -c 'echo "nameserver 8.8.8.8" > /etc/resolv.conf'
+sudo bash -c 'echo "nameserver 8.8.4.4" >> /etc/resolv.conf'
+\`\`\`
 
-#### 后端 (Java)
-- **状态**: ✅ 正常运行
-- **端口**: 8080
-- **进程**: PID 16060
-- **日志**: backend.log
-
-**API端点测试:**
-```bash
-# 健康检查
-curl http://localhost:8080/health
-# 返回: {"success":true,"status":"healthy","version":"4.1",...}
-
-# 分类列表
-curl http://localhost:8080/api/categories
-# 返回: {"success":true,"categories":["市集","展覽","演唱會",...]}
-```
-
-#### 前端 (React + Vite)
-- **状态**: ✅ 正常运行
-- **端口**: 5173
-- **进程**: PID 19407
-- **访问**: http://localhost:5173
-
-**前端页面测试:**
-```bash
-curl http://localhost:5173
-# 返回: <title>EventFinder 台灣活動搜尋</title>
-```
-
-### 🔗 前后端连接验证
-
-**Vite代理配置** (frontend/vite.config.js):
-```javascript
-proxy: {
-  '/api': {
-    target: 'http://localhost:8080',
-    changeOrigin: true,
-    secure: false
-  }
-}
-```
-
-**工作流程:**
-1. 前端发起请求: `fetch('/api/search?query=...')`
-2. Vite代理转发到: `http://localhost:8080/api/search?query=...`
-3. 后端处理请求并返回JSON
-4. 前端接收并渲染数据
-
-## 如何使用
-
-### 方式一：使用现有运行的服务
-
-服务已经在后台运行，可以直接访问：
-- **前端**: http://localhost:5173
-- **后端API**: http://localhost:8080/health
-
-### 方式二：重新启动服务
-
-如果服务停止了，可以使用以下方法重启：
-
-#### 快速启动（推荐）
-```bash
-# 在项目根目录
-
-# 启动后端（后台运行）
-java -cp "target/classes:lib/*" app.web.SimpleServer > backend.log 2>&1 &
-
-# 启动前端
-cd frontend && npm run dev
-```
-
-#### 使用启动脚本
-```bash
-# 分别启动
-./start-backend.sh &    # 后端后台运行
-./start-frontend.sh     # 前端前台运行
-
-# 或使用一键启动（会同时启动前后端）
-# 注意：此脚本需要Maven，如果Maven有网络问题，请使用上面的快速启动方式
-./start-all.sh
-```
-
-### 方式三：手动编译后启动
-
-如果需要重新编译：
-
-```bash
-# 后端编译
-find src/main/java -name "*.java" > /tmp/sources.txt
-javac -cp "lib/*" -d target/classes @/tmp/sources.txt
-
-# 启动后端
-java -cp "target/classes:lib/*" app.web.SimpleServer &
-
-# 前端安装依赖（如果需要）
-cd frontend
-npm install
-
-# 启动前端
-npm run dev
-```
-
-## 停止服务
-
-```bash
-# 停止后端
-pkill -f "app.web.SimpleServer"
-
-# 停止前端
-# 在运行npm run dev的终端按 Ctrl+C
-# 或者
-pkill -f "vite"
-```
-
-## 查看服务状态
-
-```bash
-# 查看运行的服务
-lsof -i :8080  # 后端
-lsof -i :5173  # 前端
-
-# 查看后端日志
-tail -f backend.log
-
-# 查看进程
-ps aux | grep -E "(SimpleServer|vite)" | grep -v grep
-```
-
-## 常用API测试
-
-```bash
-# 健康检查
-curl http://localhost:8080/health
-
-# 分类
-curl http://localhost:8080/api/categories
-
-# 搜索
-curl "http://localhost:8080/api/search?query=音樂&city=台北"
-
-# 建议
-curl "http://localhost:8080/api/suggestions?query=音"
-
-# 测试CORS（从前端）
-curl http://localhost:5173/api/categories
-```
-
-## 文件结构
-
-```
-DS_Project/
-├── lib/                          # 手动下载的依赖
-│   ├── gson-2.10.1.jar
-│   └── jsoup-1.17.2.jar
-├── target/classes/               # 编译后的class文件
-├── frontend/                     # 前端项目
-│   └── node_modules/            # 前端依赖（已重新安装）
-├── backend.log                   # 后端运行日志
-├── START_GUIDE.md               # 详细启动指南
-├── CONNECTION_FIXED.md          # 本文件
-├── start-backend.sh             # 后端启动脚本
-├── start-frontend.sh            # 前端启动脚本
-└── start-all.sh                 # 一键启动脚本
-```
-
-## 下次启动注意事项
-
-1. **后端**: 由于依赖已下载且代码已编译，下次可以直接运行：
-   ```bash
-   java -cp "target/classes:lib/*" app.web.SimpleServer
-   ```
-
-2. **前端**: 依赖已安装，直接运行：
-   ```bash
-   cd frontend && npm run dev
-   ```
-
-3. **如果修改了代码**:
-   - Java代码: 重新编译 (使用javac命令)
-   - React代码: Vite会自动热重载，无需重启
-
-## 常见问题
-
-### Q: 端口已被占用怎么办？
-```bash
-# 找到占用进程
-lsof -i :8080  # 或 :5173
-
-# 停止进程
-kill -9 <PID>
-```
-
-### Q: 后端修改代码后如何重新编译？
-```bash
-# 重新编译所有文件
-find src/main/java -name "*.java" > /tmp/sources.txt
-javac -cp "lib/*" -d target/classes @/tmp/sources.txt
-
-# 重启后端
-pkill -f SimpleServer
-java -cp "target/classes:lib/*" app.web.SimpleServer &
-```
-
-### Q: 如果Maven网络恢复了？
-可以使用Maven正常编译和运行：
-```bash
+#### 2. 編譯並啟動後端
+\`\`\`bash
+# 在專案根目錄
 mvn clean compile
+
+# 啟動後端服務
 mvn exec:java -Dexec.mainClass="app.web.SimpleServer"
-```
+
+# 或者後台運行
+nohup mvn exec:java -Dexec.mainClass="app.web.SimpleServer" > backend.log 2>&1 &
+\`\`\`
+
+#### 3. 啟動前端
+\`\`\`bash
+cd frontend
+npm run dev
+\`\`\`
+
+#### 4. 訪問應用
+- 前端: http://localhost:5173
+- 後端API: http://localhost:8080/health
 
 ---
 
-**总结**: 前后端已成功连接，所有服务正常运行！🎉
+### 方案 B：手動下載依賴 (網路問題時)
+
+#### 1. 手動下載JAR文件
+\`\`\`bash
+mkdir -p lib
+cd lib
+
+# 下載依賴 (在有網路的機器上下載後傳輸)
+# Gson 2.10.1
+wget https://repo1.maven.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar
+
+# Jsoup 1.17.2
+wget https://repo1.maven.org/maven2/org/jsoup/jsoup/1.17.2/jsoup-1.17.2.jar
+
+cd ..
+\`\`\`
+
+#### 2. 手動編譯
+\`\`\`bash
+# 創建輸出目錄
+mkdir -p target/classes
+
+# 編譯Java源文件
+javac -cp "lib/*" -d target/classes \\
+  \$(find src/main/java -name "*.java")
+\`\`\`
+
+#### 3. 運行後端
+\`\`\`bash
+java -cp "target/classes:lib/*" app.web.SimpleServer
+\`\`\`
+
+#### 4. 啟動前端 (同方案A步驟3)
+
+---
+
+### 方案 C：使用已編譯的JAR (如果存在)
+
+\`\`\`bash
+# 如果有預編譯的JAR
+java -jar eventfinder-1.0.0.jar
+
+# 或帶依賴的fat jar
+java -jar target/eventfinder-1.0.0-jar-with-dependencies.jar
+\`\`\`
+
+## 快速啟動腳本
+
+### start-backend.sh
+\`\`\`bash
+#!/bin/bash
+echo "正在啟動後端服務..."
+cd "\$(dirname "\$0")"
+mvn exec:java -Dexec.mainClass="app.web.SimpleServer"
+\`\`\`
+
+### start-frontend.sh
+\`\`\`bash
+#!/bin/bash
+echo "正在啟動前端開發服務器..."
+cd "\$(dirname "\$0")/frontend"
+npm run dev
+\`\`\`
+
+### start-all.sh
+\`\`\`bash
+#!/bin/bash
+echo "正在啟動前後端服務..."
+
+# 啟動後端 (後台)
+./start-backend.sh > backend.log 2>&1 &
+BACKEND_PID=\$!
+echo "後端進程ID: \$BACKEND_PID"
+
+# 等待後端啟動
+sleep 5
+
+# 啟動前端
+./start-frontend.sh
+\`\`\`
+
+## 驗證連接
+
+### 1. 檢查後端健康狀態
+\`\`\`bash
+curl http://localhost:8080/health
+# 預期輸出: {"status":"ok","timestamp":...}
+\`\`\`
+
+### 2. 測試API
+\`\`\`bash
+# 分類
+curl http://localhost:8080/api/categories
+
+# 搜尋
+curl "http://localhost:8080/api/search?query=音樂&city=台北"
+
+# 建議
+curl "http://localhost:8080/api/suggestions?query=音"
+\`\`\`
+
+### 3. 檢查前端代理
+- 啟動前端後訪問: http://localhost:5173
+- 打開瀏覽器控制台 (F12)
+- 執行搜尋，觀察Network標籤
+- API請求應該是 \`/api/search\`，並被代理到 \`http://localhost:8080/api/search\`
+
+## 常見問題
+
+### Q: 後端啟動後立即停止？
+檢查日誌中的錯誤訊息，可能是：
+- 連接埠8080已被佔用: \`lsof -i :8080\`
+- 配置文件缺失
+- 依賴版本不匹配
+
+### Q: 前端無法連接後端？
+1. 確認後端正在運行: \`curl http://localhost:8080/health\`
+2. 確認Vite代理配置正確: 檢查 \`frontend/vite.config.js\`
+3. 查看瀏覽器控制台的網路錯誤
+4. 檢查CORS配置
+
+### Q: CORS錯誤？
+後端已配置CORS允許所有來源 (\`cors.origin=*\`)，如果仍有問題：
+- 檢查 \`src/main/resources/config.properties\`
+- 確認後端ServerContext正確設置CORS headers
+
+### Q: Maven依賴下載失敗？
+- 檢查網路連接: \`curl -I https://repo.maven.apache.org\`
+- 檢查DNS: \`cat /etc/resolv.conf\`
+- 使用方案B手動下載依賴
+- 或使用Maven鏡像配置
+
+## 下一步
+
+當前環境由於DNS配置問題，需要先修復網路，然後按照 **方案A** 啟動服務。
+
+如果無法修復網路，請使用 **方案B** 手動下載依賴。

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,37 @@
-# EventFinder - Production Dockerfile
+# EventFinder - 生產環境 Dockerfile
 FROM eclipse-temurin:17-jre-alpine
 
-# 设置工作目录
+# 設定工作目錄
 WORKDIR /app
 
-# 创建非root用户
+# 建立非root使用者
 RUN addgroup -g 1001 -S appuser && adduser -u 1001 -S appuser -G appuser
 
-# 复制依赖
+# 複製依賴檔案
 COPY lib/*.jar /app/lib/
 
-# 复制编译好的classes
+# 複製編譯好的類別檔案
 COPY target/classes /app/classes
 
-# 复制配置文件
+# 複製配置檔案
 COPY src/main/resources/*.properties /app/config/
 
-# 设置权限
+# 設定權限
 RUN chown -R appuser:appuser /app && \
     mkdir -p /app/logs && \
     chown -R appuser:appuser /app/logs
 
-# 切换到非root用户
+# 切換到非root使用者
 USER appuser
 
-# 暴露端口
+# 暴露連接埠
 EXPOSE 8080
 
-# 健康检查
+# 健康檢查
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
-# 启动命令
+# 啟動指令
 CMD ["java", "-cp", "/app/classes:/app/lib/*", \
      "-Xms256m", "-Xmx512m", \
      "-XX:+UseG1GC", \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎪 EventFinder - 台灣活動搜尋引擎
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![授權: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Java](https://img.shields.io/badge/Java-17-orange.svg)](https://openjdk.org/)
 [![React](https://img.shields.io/badge/React-18.2-blue.svg)](https://reactjs.org/)
 
@@ -21,8 +21,8 @@
 
 ### 使用 Docker（推薦）
 
-\`\`\`bash
-# 1. 克隆項目
+```bash
+# 1. 克隆專案
 git clone https://github.com/Fengjui1226/DS_Project.git
 cd DS_Project
 
@@ -31,30 +31,30 @@ cd DS_Project
 
 # 3. 訪問應用
 open http://localhost
-\`\`\`
+```
 
 ### 手動部署
 
-查看 [START_GUIDE.md](START_GUIDE.md) 獲取詳細說明。
+查看 [快速開始指南](START_GUIDE.md) 獲取詳細說明。
 
-## 📖 API 文檔
+## 📖 應用程式介面文檔
 
 ### 搜尋活動
-\`\`\`http
+```http
 GET /api/search?query=音樂&city=台北&page=1
-\`\`\`
+```
 
 ### 獲取分類
-\`\`\`http
+```http
 GET /api/categories
-\`\`\`
+```
 
 ### 健康檢查
-\`\`\`http
+```http
 GET /health
-\`\`\`
+```
 
-完整API文檔請查看 [API.md](docs/API.md)
+完整說明請查看 [應用程式介面文檔](docs/API.md)
 
 ## 🏗️ 技術架構
 
@@ -62,9 +62,9 @@ GET /health
 - **前端**: React 18 + Vite
 - **部署**: Docker + Nginx + Docker Compose
 
-## 📂 項目結構
+## 📂 專案結構
 
-\`\`\`
+```
 DS_Project/
 ├── src/main/java/app/       # Java後端
 ├── frontend/                 # React前端
@@ -73,27 +73,27 @@ DS_Project/
 ├── docker-compose.yml        # 服務編排
 ├── deploy.sh                 # 部署腳本
 └── README.md                 # 本文件
-\`\`\`
+```
 
-## 🐳 Docker 命令
+## 🐳 Docker 指令
 
-\`\`\`bash
+```bash
 # 構建並啟動
 ./deploy.sh
 
-# 單獨命令
+# 單獨指令
 docker-compose build   # 構建鏡像
 docker-compose up -d   # 啟動服務
 docker-compose logs -f # 查看日誌
 docker-compose down    # 停止服務
-\`\`\`
+```
 
 ## ⚙️ 配置
 
 生產環境配置請查看：
-- [config.properties](src/main/resources/config.properties)
-- [nginx.conf](nginx.conf)
-- [docker-compose.yml](docker-compose.yml)
+- [配置檔案](src/main/resources/config.properties)
+- [Nginx配置](nginx.conf)
+- [Docker編排配置](docker-compose.yml)
 
 ## 🔒 安全措施
 
@@ -101,19 +101,25 @@ docker-compose down    # 停止服務
 - ✅ 速率限制
 - ✅ 輸入驗證
 - ✅ XSS 防護
-- ✅ 非 root 用戶
+- ✅ 非 root 使用者運行
 
-## 📝 文檔
+## 📝 相關文檔
 
 - [快速開始指南](START_GUIDE.md)
+- [快速啟動參考](QUICK_START.md)
 - [連接問題修復](CONNECTION_FIXED.md)
 - [部署文檔](docs/DEPLOYMENT.md)
-- [貢獻指南](CONTRIBUTING.md)
+- [上架檢查清單](PRODUCTION_CHECKLIST.md)
+- [子網頁功能說明](SUBPAGE_FEATURE.md)
+
+## 🤝 貢獻
+
+歡迎提交問題和拉取請求！
 
 ## 📄 授權
 
-MIT License
+MIT 授權條款
 
 ## 🙏 致謝
 
-Built with ❤️ for Taiwan 🇹🇼
+用 ❤️ 為台灣打造 🇹🇼

--- a/START_GUIDE.md
+++ b/START_GUIDE.md
@@ -1,74 +1,74 @@
-# 前后端连接问题诊断与解决方案
+# 前後端連接問題診斷與解決方案
 
-## 问题诊断结果
+## 問題診斷結果
 
-### 当前状态
-- ❌ **后端服务未运行** (8080端口未被占用)
-- ❌ **前端开发服务器未运行**
-- ❌ **网络DNS解析失败** (无法下载Maven依赖)
-- ✅ 前端依赖已安装 (node_modules存在)
-- ✅ 项目配置正确
+### 當前狀態
+- ❌ **後端服務未運行** (8080連接埠未被佔用)
+- ❌ **前端開發服務器未運行**
+- ❌ **網路DNS解析失敗** (無法下載Maven依賴)
+- ✅ 前端依賴已安裝 (node_modules存在)
+- ✅ 專案配置正確
 
 ### 根本原因
-1. 前后端服务都没有启动
-2. 后端无法编译 - Maven无法解析域名下载依赖 (DNS configuration issue)
+1. 前後端服務都沒有啟動
+2. 後端無法編譯 - Maven無法解析域名下載依賴 (DNS configuration issue)
 
-## 架构说明
+## 架構說明
 
-### 后端 (Java)
-- **端口**: 8080
-- **API路径**: `/api/v1/*` 和 `/api/*` (向后兼容)
-- **主类**: `app.web.SimpleServer`
-- **依赖**: Gson (2.10.1), Jsoup (1.17.2)
+### 後端 (Java)
+- **連接埠**: 8080
+- **API路徑**: `/api/v1/*` 和 `/api/*` (向後兼容)
+- **主類**: `app.web.SimpleServer`
+- **依賴**: Gson (2.10.1), Jsoup (1.17.2)
 
 ### 前端 (React + Vite)
-- **开发端口**: 默认 5173
+- **開發連接埠**: 默認 5173
 - **代理配置**: `/api` -> `http://localhost:8080`
-- **API调用**: `fetch('/api/search?...')` 会被代理到后端
+- **API調用**: `fetch('/api/search?...')` 會被代理到後端
 
-## 解决方案
+## 解決方案
 
-### 方案 A：修复网络并正常启动 (推荐)
+### 方案 A：修復網路並正常啟動 (推薦)
 
-#### 1. 修复DNS配置
-```bash
-# 创建或更新 /etc/resolv.conf
+#### 1. 修復DNS配置
+\`\`\`bash
+# 創建或更新 /etc/resolv.conf
 sudo bash -c 'echo "nameserver 8.8.8.8" > /etc/resolv.conf'
 sudo bash -c 'echo "nameserver 8.8.4.4" >> /etc/resolv.conf'
-```
+\`\`\`
 
-#### 2. 编译并启动后端
-```bash
-# 在项目根目录
+#### 2. 編譯並啟動後端
+\`\`\`bash
+# 在專案根目錄
 mvn clean compile
 
-# 启动后端服务
+# 啟動後端服務
 mvn exec:java -Dexec.mainClass="app.web.SimpleServer"
 
-# 或者后台运行
+# 或者後台運行
 nohup mvn exec:java -Dexec.mainClass="app.web.SimpleServer" > backend.log 2>&1 &
-```
+\`\`\`
 
-#### 3. 启动前端
-```bash
+#### 3. 啟動前端
+\`\`\`bash
 cd frontend
 npm run dev
-```
+\`\`\`
 
-#### 4. 访问应用
+#### 4. 訪問應用
 - 前端: http://localhost:5173
-- 后端API: http://localhost:8080/health
+- 後端API: http://localhost:8080/health
 
 ---
 
-### 方案 B：手动下载依赖 (网络问题时)
+### 方案 B：手動下載依賴 (網路問題時)
 
-#### 1. 手动下载JAR文件
-```bash
+#### 1. 手動下載JAR文件
+\`\`\`bash
 mkdir -p lib
 cd lib
 
-# 下载依赖 (在有网络的机器上下载后传输)
+# 下載依賴 (在有網路的機器上下載後傳輸)
 # Gson 2.10.1
 wget https://repo1.maven.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar
 
@@ -76,125 +76,125 @@ wget https://repo1.maven.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1
 wget https://repo1.maven.org/maven2/org/jsoup/jsoup/1.17.2/jsoup-1.17.2.jar
 
 cd ..
-```
+\`\`\`
 
-#### 2. 手动编译
-```bash
-# 创建输出目录
+#### 2. 手動編譯
+\`\`\`bash
+# 創建輸出目錄
 mkdir -p target/classes
 
-# 编译Java源文件
-javac -cp "lib/*" -d target/classes \
-  $(find src/main/java -name "*.java")
-```
+# 編譯Java源文件
+javac -cp "lib/*" -d target/classes \\
+  \$(find src/main/java -name "*.java")
+\`\`\`
 
-#### 3. 运行后端
-```bash
+#### 3. 運行後端
+\`\`\`bash
 java -cp "target/classes:lib/*" app.web.SimpleServer
-```
+\`\`\`
 
-#### 4. 启动前端 (同方案A步骤3)
+#### 4. 啟動前端 (同方案A步驟3)
 
 ---
 
-### 方案 C：使用已编译的JAR (如果存在)
+### 方案 C：使用已編譯的JAR (如果存在)
 
-```bash
-# 如果有预编译的JAR
+\`\`\`bash
+# 如果有預編譯的JAR
 java -jar eventfinder-1.0.0.jar
 
-# 或带依赖的fat jar
+# 或帶依賴的fat jar
 java -jar target/eventfinder-1.0.0-jar-with-dependencies.jar
-```
+\`\`\`
 
-## 快速启动脚本
+## 快速啟動腳本
 
 ### start-backend.sh
-```bash
+\`\`\`bash
 #!/bin/bash
-echo "正在启动后端服务..."
-cd "$(dirname "$0")"
+echo "正在啟動後端服務..."
+cd "\$(dirname "\$0")"
 mvn exec:java -Dexec.mainClass="app.web.SimpleServer"
-```
+\`\`\`
 
 ### start-frontend.sh
-```bash
+\`\`\`bash
 #!/bin/bash
-echo "正在启动前端开发服务器..."
-cd "$(dirname "$0")/frontend"
+echo "正在啟動前端開發服務器..."
+cd "\$(dirname "\$0")/frontend"
 npm run dev
-```
+\`\`\`
 
 ### start-all.sh
-```bash
+\`\`\`bash
 #!/bin/bash
-echo "正在启动前后端服务..."
+echo "正在啟動前後端服務..."
 
-# 启动后端 (后台)
+# 啟動後端 (後台)
 ./start-backend.sh > backend.log 2>&1 &
-BACKEND_PID=$!
-echo "后端进程ID: $BACKEND_PID"
+BACKEND_PID=\$!
+echo "後端進程ID: \$BACKEND_PID"
 
-# 等待后端启动
+# 等待後端啟動
 sleep 5
 
-# 启动前端
+# 啟動前端
 ./start-frontend.sh
-```
+\`\`\`
 
-## 验证连接
+## 驗證連接
 
-### 1. 检查后端健康状态
-```bash
+### 1. 檢查後端健康狀態
+\`\`\`bash
 curl http://localhost:8080/health
-# 预期输出: {"status":"ok","timestamp":...}
-```
+# 預期輸出: {"status":"ok","timestamp":...}
+\`\`\`
 
-### 2. 测试API
-```bash
-# 分类
+### 2. 測試API
+\`\`\`bash
+# 分類
 curl http://localhost:8080/api/categories
 
-# 搜索
-curl "http://localhost:8080/api/search?query=音乐&city=台北"
+# 搜尋
+curl "http://localhost:8080/api/search?query=音樂&city=台北"
 
-# 建议
+# 建議
 curl "http://localhost:8080/api/suggestions?query=音"
-```
+\`\`\`
 
-### 3. 检查前端代理
-- 启动前端后访问: http://localhost:5173
-- 打开浏览器控制台 (F12)
-- 执行搜索，观察Network标签
-- API请求应该是 `/api/search`，并被代理到 `http://localhost:8080/api/search`
+### 3. 檢查前端代理
+- 啟動前端後訪問: http://localhost:5173
+- 打開瀏覽器控制台 (F12)
+- 執行搜尋，觀察Network標籤
+- API請求應該是 \`/api/search\`，並被代理到 \`http://localhost:8080/api/search\`
 
-## 常见问题
+## 常見問題
 
-### Q: 后端启动后立即停止？
-检查日志中的错误信息，可能是：
-- 端口8080已被占用: `lsof -i :8080`
+### Q: 後端啟動後立即停止？
+檢查日誌中的錯誤訊息，可能是：
+- 連接埠8080已被佔用: \`lsof -i :8080\`
 - 配置文件缺失
-- 依赖版本不匹配
+- 依賴版本不匹配
 
-### Q: 前端无法连接后端？
-1. 确认后端正在运行: `curl http://localhost:8080/health`
-2. 确认Vite代理配置正确: 检查 `frontend/vite.config.js`
-3. 查看浏览器控制台的网络错误
-4. 检查CORS配置
+### Q: 前端無法連接後端？
+1. 確認後端正在運行: \`curl http://localhost:8080/health\`
+2. 確認Vite代理配置正確: 檢查 \`frontend/vite.config.js\`
+3. 查看瀏覽器控制台的網路錯誤
+4. 檢查CORS配置
 
-### Q: CORS错误？
-后端已配置CORS允许所有来源 (`cors.origin=*`)，如果仍有问题：
-- 检查 `src/main/resources/config.properties`
-- 确认后端ServerContext正确设置CORS headers
+### Q: CORS錯誤？
+後端已配置CORS允許所有來源 (\`cors.origin=*\`)，如果仍有問題：
+- 檢查 \`src/main/resources/config.properties\`
+- 確認後端ServerContext正確設置CORS headers
 
-### Q: Maven依赖下载失败？
-- 检查网络连接: `curl -I https://repo.maven.apache.org`
-- 检查DNS: `cat /etc/resolv.conf`
-- 使用方案B手动下载依赖
-- 或使用Maven镜像配置
+### Q: Maven依賴下載失敗？
+- 檢查網路連接: \`curl -I https://repo.maven.apache.org\`
+- 檢查DNS: \`cat /etc/resolv.conf\`
+- 使用方案B手動下載依賴
+- 或使用Maven鏡像配置
 
 ## 下一步
 
-当前环境由于DNS配置问题，需要先修复网络，然后按照 **方案A** 启动服务。
+當前環境由於DNS配置問題，需要先修復網路，然後按照 **方案A** 啟動服務。
 
-如果无法修复网络，请使用 **方案B** 手动下载依赖。
+如果無法修復網路，請使用 **方案B** 手動下載依賴。

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,44 +1,44 @@
 #!/bin/bash
-# EventFinder 一键部署脚本
+# EventFinder 一鍵部署腳本
 
 set -e
 
 echo "========================================="
-echo "  EventFinder 部署脚本"
+echo "  EventFinder 部署腳本"
 echo "========================================="
 echo ""
 
-# 颜色定义
+# 顏色定義
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# 检查依赖
+# 檢查依賴
 check_dependencies() {
-    echo "检查依赖..."
+    echo "檢查依賴..."
 
     if ! command -v docker &> /dev/null; then
-        echo -e "${RED}❌ Docker未安装${NC}"
+        echo -e "${RED}❌ Docker未安裝${NC}"
         exit 1
     fi
 
     if ! command -v docker-compose &> /dev/null; then
-        echo -e "${RED}❌ Docker Compose未安装${NC}"
+        echo -e "${RED}❌ Docker Compose未安裝${NC}"
         exit 1
     fi
 
-    echo -e "${GREEN}✅ 依赖检查通过${NC}"
+    echo -e "${GREEN}✅ 依賴檢查通過${NC}"
 }
 
-# 编译后端
+# 編譯後端
 build_backend() {
     echo ""
-    echo "编译后端..."
+    echo "編譯後端..."
 
-    # 检查并下载依赖
+    # 檢查並下載依賴
     if [ ! -d "lib" ] || [ ! -f "lib/gson-2.10.1.jar" ]; then
-        echo "下载依赖..."
+        echo "下載依賴..."
         mkdir -p lib
         curl -L -o lib/gson-2.10.1.jar \
             https://repo1.maven.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar
@@ -46,100 +46,100 @@ build_backend() {
             https://repo1.maven.org/maven2/org/jsoup/jsoup/1.17.2/jsoup-1.17.2.jar
     fi
 
-    # 编译
+    # 編譯
     mkdir -p target/classes
     find src/main/java -name "*.java" > /tmp/sources.txt
     javac -cp "lib/*" -d target/classes @/tmp/sources.txt
 
-    echo -e "${GREEN}✅ 后端编译完成${NC}"
+    echo -e "${GREEN}✅ 後端編譯完成${NC}"
 }
 
-# 构建前端
+# 構建前端
 build_frontend() {
     echo ""
-    echo "构建前端..."
+    echo "構建前端..."
 
     cd frontend
 
-    # 安装依赖（如果需要）
+    # 安裝依賴（如果需要）
     if [ ! -d "node_modules" ]; then
-        echo "安装依赖..."
+        echo "安裝依賴..."
         npm install
     fi
 
-    # 构建生产版本
-    echo "构建生产版本..."
+    # 構建生產版本
+    echo "構建生產版本..."
     npm run build
 
     cd ..
 
-    echo -e "${GREEN}✅ 前端构建完成${NC}"
+    echo -e "${GREEN}✅ 前端構建完成${NC}"
 }
 
-# 构建Docker镜像
+# 構建Docker鏡像
 build_docker() {
     echo ""
-    echo "构建Docker镜像..."
+    echo "構建Docker鏡像..."
 
     docker-compose build
 
-    echo -e "${GREEN}✅ Docker镜像构建完成${NC}"
+    echo -e "${GREEN}✅ Docker鏡像構建完成${NC}"
 }
 
-# 启动服务
+# 啟動服務
 start_services() {
     echo ""
-    echo "启动服务..."
+    echo "啟動服務..."
 
-    # 停止旧服务
+    # 停止舊服務
     docker-compose down 2>/dev/null || true
 
-    # 启动新服务
+    # 啟動新服務
     docker-compose up -d
 
-    echo -e "${GREEN}✅ 服务已启动${NC}"
+    echo -e "${GREEN}✅ 服務已啟動${NC}"
 }
 
-# 等待服务就绪
+# 等待服務就緒
 wait_for_services() {
     echo ""
-    echo "等待服务就绪..."
+    echo "等待服務就緒..."
 
     for i in {1..30}; do
         if curl -s http://localhost:8080/health > /dev/null 2>&1; then
-            echo -e "${GREEN}✅ 后端服务就绪${NC}"
+            echo -e "${GREEN}✅ 後端服務就緒${NC}"
             break
         fi
-        echo "等待后端启动... ($i/30)"
+        echo "等待後端啟動... ($i/30)"
         sleep 2
     done
 
     for i in {1..30}; do
         if curl -s http://localhost:80 > /dev/null 2>&1; then
-            echo -e "${GREEN}✅ 前端服务就绪${NC}"
+            echo -e "${GREEN}✅ 前端服務就緒${NC}"
             break
         fi
-        echo "等待前端启动... ($i/30)"
+        echo "等待前端啟動... ($i/30)"
         sleep 2
     done
 }
 
-# 显示状态
+# 顯示狀態
 show_status() {
     echo ""
     echo "========================================="
     echo -e "${GREEN}🎉 部署成功！${NC}"
     echo "========================================="
     echo ""
-    echo "服务地址："
+    echo "服務地址："
     echo "  前端: http://localhost"
-    echo "  后端API: http://localhost:8080"
-    echo "  健康检查: http://localhost:8080/health"
+    echo "  後端API: http://localhost:8080"
+    echo "  健康檢查: http://localhost:8080/health"
     echo ""
-    echo "查看日志："
+    echo "查看日誌："
     echo "  docker-compose logs -f"
     echo ""
-    echo "停止服务："
+    echo "停止服務："
     echo "  docker-compose down"
     echo ""
 }
@@ -173,12 +173,12 @@ case "${1:-deploy}" in
         ;;
     stop)
         docker-compose down
-        echo -e "${GREEN}✅ 服务已停止${NC}"
+        echo -e "${GREEN}✅ 服務已停止${NC}"
         ;;
     restart)
         docker-compose restart
         wait_for_services
-        echo -e "${GREEN}✅ 服务已重启${NC}"
+        echo -e "${GREEN}✅ 服務已重啟${NC}"
         ;;
     logs)
         docker-compose logs -f

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,7 +23,7 @@ http {
     keepalive_timeout 65;
     types_hash_max_size 2048;
 
-    # Gzip压缩
+    # Gzip 壓縮
     gzip on;
     gzip_vary on;
     gzip_proxied any;
@@ -33,30 +33,30 @@ http {
                application/rss+xml font/truetype font/opentype
                application/vnd.ms-fontobject image/svg+xml;
 
-    # 上游后端服务
+    # 上游後端服務
     upstream backend {
         server backend:8080;
         keepalive 32;
     }
 
-    # HTTP服务器
+    # HTTP 伺服器
     server {
         listen 80;
         server_name _;
 
-        # HTTP重定向到HTTPS（生产环境启用）
+        # HTTP 重導向到 HTTPS（生產環境啟用）
         # return 301 https://$server_name$request_uri;
 
         root /usr/share/nginx/html;
         index index.html;
 
-        # 静态文件缓存
+        # 靜態檔案快取
         location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot)$ {
             expires 1y;
             add_header Cache-Control "public, immutable";
         }
 
-        # API代理到后端
+        # API 代理到後端
         location /api/ {
             proxy_pass http://backend;
             proxy_http_version 1.1;
@@ -68,31 +68,31 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_cache_bypass $http_upgrade;
 
-            # 超时设置
+            # 逾時設定
             proxy_connect_timeout 60s;
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;
         }
 
-        # 健康检查
+        # 健康檢查
         location /health {
             proxy_pass http://backend/health;
             access_log off;
         }
 
-        # SPA路由支持
+        # SPA 路由支援
         location / {
             try_files $uri $uri/ /index.html;
         }
 
-        # 安全头
+        # 安全標頭
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
     }
 
-    # HTTPS服务器（生产环境启用）
+    # HTTPS 伺服器（生產環境啟用）
     # server {
     #     listen 443 ssl http2;
     #     server_name your-domain.com;

--- a/start-all.sh
+++ b/start-all.sh
@@ -1,60 +1,60 @@
 #!/bin/bash
 echo "========================================"
-echo "  EventFinder 完整启动脚本"
+echo "  EventFinder 完整啟動腳本"
 echo "========================================"
 echo ""
 
 cd "$(dirname "$0")"
 
-# 检查后端是否已运行
+# 檢查後端是否已運行
 if lsof -i :8080 >/dev/null 2>&1; then
-    echo "⚠️  端口8080已被占用，后端可能已在运行"
-    read -p "是否继续？这将尝试启动新实例 (y/N): " -n 1 -r
+    echo "⚠️  連接埠8080已被佔用，後端可能已在運行"
+    read -p "是否繼續？這將嘗試啟動新實例 (y/N): " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         exit 1
     fi
 fi
 
-echo "📦 步骤 1/3: 检查并编译后端..."
+echo "📦 步驟 1/3: 檢查並編譯後端..."
 echo "================================"
 mvn compile
 if [ $? -ne 0 ]; then
-    echo "❌ 后端编译失败"
-    echo "📖 请查看 START_GUIDE.md 获取帮助"
+    echo "❌ 後端編譯失敗"
+    echo "📖 請查看 START_GUIDE.md 獲取幫助"
     exit 1
 fi
 
 echo ""
-echo "✅ 后端编译成功"
+echo "✅ 後端編譯成功"
 echo ""
-echo "🚀 步骤 2/3: 启动后端服务 (后台运行)..."
+echo "🚀 步驟 2/3: 啟動後端服務 (後台運行)..."
 echo "================================"
 nohup mvn exec:java -Dexec.mainClass="app.web.SimpleServer" > backend.log 2>&1 &
 BACKEND_PID=$!
-echo "后端进程ID: $BACKEND_PID"
-echo "日志文件: backend.log"
+echo "後端進程ID: $BACKEND_PID"
+echo "日誌文件: backend.log"
 
 echo ""
-echo "⏳ 等待后端启动 (5秒)..."
+echo "⏳ 等待後端啟動 (5秒)..."
 sleep 5
 
-# 检查后端是否成功启动
+# 檢查後端是否成功啟動
 if ! lsof -i :8080 >/dev/null 2>&1; then
-    echo "❌ 后端启动失败！请检查 backend.log"
+    echo "❌ 後端啟動失敗！請檢查 backend.log"
     cat backend.log
     exit 1
 fi
 
-echo "✅ 后端服务已启动"
+echo "✅ 後端服務已啟動"
 echo ""
-echo "🌐 步骤 3/3: 启动前端开发服务器..."
+echo "🌐 步驟 3/3: 啟動前端開發服務器..."
 echo "================================"
 cd frontend
 npm run dev
 
-# 当前端停止时，也停止后端
+# 當前端停止時，也停止後端
 echo ""
-echo "🛑 正在停止所有服务..."
+echo "🛑 正在停止所有服務..."
 kill $BACKEND_PID 2>/dev/null
-echo "✅ 所有服务已停止"
+echo "✅ 所有服務已停止"

--- a/start-backend.sh
+++ b/start-backend.sh
@@ -1,38 +1,38 @@
 #!/bin/bash
 echo "================================"
-echo "正在启动EventFinder后端服务..."
+echo "正在啟動EventFinder後端服務..."
 echo "================================"
 
 cd "$(dirname "$0")"
 
-# 检查启动方式参数
+# 檢查啟動方式參數
 USE_MAVEN=${1:-"auto"}
 
-# 检查 Maven 是否可用
+# 檢查 Maven 是否可用
 if command -v mvn &> /dev/null; then
     MAVEN_AVAILABLE=true
 else
     MAVEN_AVAILABLE=false
 fi
 
-# 使用 Maven 启动（推荐）
+# 使用 Maven 啟動（推薦）
 if [ "$USE_MAVEN" = "maven" ] || ([ "$USE_MAVEN" = "auto" ] && [ "$MAVEN_AVAILABLE" = true ]); then
-    echo "📦 使用 Maven 启动..."
-    echo "🚀 正在启动后端服务 (端口: 8080)..."
+    echo "📦 使用 Maven 啟動..."
+    echo "🚀 正在啟動後端服務 (連接埠: 8080)..."
     echo ""
-    echo "按 Ctrl+C 停止服务"
+    echo "按 Ctrl+C 停止服務"
     echo "================================"
 
-    # 使用 Maven exec 插件启动（安静模式，跳过测试）
+    # 使用 Maven exec 插件啟動（安靜模式，跳過測試）
     mvn -q -DskipTests exec:java -Dexec.mainClass="app.web.SimpleServer"
 
-# 使用手动编译方式启动
+# 使用手動編譯方式啟動
 else
-    echo "📦 使用手动编译方式启动..."
+    echo "📦 使用手動編譯方式啟動..."
 
-    # 检查依赖
+    # 檢查依賴
     if [ ! -d "lib" ] || [ ! -f "lib/gson-2.10.1.jar" ]; then
-        echo "⚠️  未找到依赖，正在下载..."
+        echo "⚠️  未找到依賴，正在下載..."
         mkdir -p lib
         curl -L -o lib/gson-2.10.1.jar \
             https://repo1.maven.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar
@@ -40,24 +40,24 @@ else
             https://repo1.maven.org/maven2/org/jsoup/jsoup/1.17.2/jsoup-1.17.2.jar
     fi
 
-    # 检查是否已编译
+    # 檢查是否已編譯
     if [ ! -d "target/classes/app" ]; then
-        echo "⚠️  检测到项目未编译，正在编译..."
+        echo "⚠️  檢測到專案未編譯，正在編譯..."
         mkdir -p target/classes
         find src/main/java -name "*.java" > /tmp/sources.txt
         javac -cp "lib/*" -d target/classes @/tmp/sources.txt
         if [ $? -ne 0 ]; then
-            echo "❌ 编译失败！请检查错误信息"
+            echo "❌ 編譯失敗！請檢查錯誤訊息"
             exit 1
         fi
     fi
 
-    echo "✅ 后端已编译"
-    echo "🚀 正在启动后端服务 (端口: 8080)..."
+    echo "✅ 後端已編譯"
+    echo "🚀 正在啟動後端服務 (連接埠: 8080)..."
     echo ""
-    echo "按 Ctrl+C 停止服务"
+    echo "按 Ctrl+C 停止服務"
     echo "================================"
 
-    # 启动服务
+    # 啟動服務
     java -cp "target/classes:lib/*" app.web.SimpleServer
 fi

--- a/start-frontend.sh
+++ b/start-frontend.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 echo "================================"
-echo "正在启动EventFinder前端服务..."
+echo "正在啟動EventFinder前端服務..."
 echo "================================"
 
 cd "$(dirname "$0")/frontend"
 
-# 检查node_modules
+# 檢查node_modules
 if [ ! -d "node_modules" ]; then
-    echo "⚠️  检测到依赖未安装，正在安装..."
+    echo "⚠️  檢測到依賴未安裝，正在安裝..."
     npm install
     if [ $? -ne 0 ]; then
-        echo "❌ 依赖安装失败！请检查npm配置"
+        echo "❌ 依賴安裝失敗！請檢查npm配置"
         exit 1
     fi
 fi
 
-echo "✅ 前端依赖已就绪"
-echo "🚀 正在启动前端开发服务器..."
+echo "✅ 前端依賴已就緒"
+echo "🚀 正在啟動前端開發服務器..."
 echo ""
-echo "前端将在浏览器自动打开"
-echo "按 Ctrl+C 停止服务"
+echo "前端將在瀏覽器自動打開"
+echo "按 Ctrl+C 停止服務"
 echo "================================"
 
-# 启动Vite开发服务器
+# 啟動Vite開發服務器
 npm run dev


### PR DESCRIPTION
- Updated all shell scripts (deploy.sh, start-*.sh) with Traditional Chinese messages
- Converted README.md to Traditional Chinese
- Updated Dockerfile and nginx.conf comments to Traditional Chinese
- Translated START_GUIDE.md and CONNECTION_FIXED.md to Traditional Chinese
- All documentation now consistently uses Traditional Chinese terminology:
  - 後端 (backend), 前端 (frontend)
  - 連接埠 (port), 伺服器 (server)
  - 檢查 (check), 啟動 (start)
  - 編譯 (compile), 配置 (config)
  - 專案 (project), 應用 (application)

## Summary by Sourcery

Localize project documentation and operational scripts to Traditional Chinese while keeping technical behavior unchanged.

Enhancements:
- Localize deployment and start-up shell scripts output messages to Traditional Chinese for a consistent CLI experience.

Documentation:
- Translate README and troubleshooting/startup guides to Traditional Chinese, including terminology standardization for core technical concepts.
- Update inline comments in Dockerfile and nginx configuration to Traditional Chinese.