### PR TITLE
Fix environment variable naming - support camelCase to SCREAMING_SNAK…

### DIFF
--- a/src/main/java/app/da/Config.java
+++ b/src/main/java/app/da/Config.java
@@ -32,12 +32,39 @@ public final class Config {
      */
     public static String get(String key, String def) {
         if (key == null) return def;
-        String envKey = key.replace('.', '_').toUpperCase();
+
+        // 將駝峰命名轉換為環境變數格式
+        // 例如：google.cse.apiKey → GOOGLE_CSE_API_KEY
+        String envKey = camelToEnvVar(key);
         String v = System.getenv(envKey);
         if (v != null && !v.isBlank()) return v;
+
         String p = P.getProperty(key);
         if (p != null && !p.isBlank()) return p;
         return def;
+    }
+
+    /**
+     * 將 camelCase 轉換為 SCREAMING_SNAKE_CASE
+     * 例如：google.cse.apiKey → GOOGLE_CSE_API_KEY
+     */
+    private static String camelToEnvVar(String key) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < key.length(); i++) {
+            char c = key.charAt(i);
+            if (c == '.') {
+                result.append('_');
+            } else if (Character.isUpperCase(c)) {
+                // 在大寫字母前加下劃線（除非是第一個字符）
+                if (i > 0 && result.charAt(result.length() - 1) != '_') {
+                    result.append('_');
+                }
+                result.append(c);
+            } else {
+                result.append(Character.toUpperCase(c));
+            }
+        }
+        return result.toString();
     }
 
     /** 方便取得 boolean */


### PR DESCRIPTION
…E_CASE

- 修復環境變數名稱轉換邏輯
- 正確處理 google.cse.apiKey → GOOGLE_CSE_API_KEY
- 添加 camelToEnvVar() 方法處理駝峰命名

## Summary by Sourcery

Fix environment variable resolution by correctly converting dotted camelCase config keys to SCREAMING_SNAKE_CASE env variable names.

Bug Fixes:
- Correct handling of environment variable names so keys like google.cse.apiKey map to GOOGLE_CSE_API_KEY.

Enhancements:
- Introduce a dedicated camelToEnvVar() helper to convert dotted camelCase keys into SCREAMING_SNAKE_CASE for environment lookup.