### PR TITLE
Update frontend to use correct Render backend URL

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,7 +12,7 @@ import './index.css';
 
 // API基礎URL - 開發環境使用代理，生產環境使用環境變量
 const API_BASE = import.meta.env.PROD
-  ? (import.meta.env.VITE_API_BASE_URL || 'https://your-backend-url.onrender.com') + '/api'
+  ? (import.meta.env.VITE_API_BASE_URL || 'https://ds-project-o9lk.onrender.com') + '/api'
   : '/api';
 
 const cities = {


### PR DESCRIPTION
修复内容：
1. 更新 API_BASE 指向正确的 Render 后端
2. 将占位符 URL 替换为实际的 Render URL: https://ds-project-o9lk.onrender.com
3. 前端现在可以正确连接到后端服务

## Summary by Sourcery

Bug Fixes:
- Fix the production API base URL so the frontend connects to the actual Render backend service instead of the placeholder URL.